### PR TITLE
Add shorthands for fixed width integer types

### DIFF
--- a/include/muu/all.h
+++ b/include/muu/all.h
@@ -36,6 +36,7 @@
 #include "half.h"
 #include "hashing.h"
 #include "integer_literals.h"
+#include "integer_aliases.h"
 #include "integral_range.h"
 #include "is_constant_evaluated.h"
 #include "iterators.h"

--- a/include/muu/core.h
+++ b/include/muu/core.h
@@ -14,6 +14,7 @@
 ///		- build.h
 ///		- for_sequence.h
 ///		- integer_literals.h
+///		- integer_aliases.h
 ///		- is_constant_evaluated.h
 ///		- launder.h
 ///		- meta.h
@@ -30,6 +31,7 @@
 #include "build.h"
 #include "for_sequence.h"
 #include "integer_literals.h"
+#include "integer_aliases.h"
 #include "is_constant_evaluated.h"
 #include "launder.h"
 #include "meta.h"

--- a/include/muu/integer_aliases.h
+++ b/include/muu/integer_aliases.h
@@ -13,7 +13,7 @@ namespace muu
 	inline namespace integer_aliases
 	{
 		using i8  = int8_t;
-		using i16 = int16_t
+		using i16 = int16_t;
 		using i32 = int32_t;
 		using i64 = int64_t;
 		using u8  = uint8_t;

--- a/include/muu/integer_aliases.h
+++ b/include/muu/integer_aliases.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+//
+
+#pragma once
+
+/// \file
+/// \brief Shorthands for fixed width integer types.
+
+#include "fwd.h"
+
+namespace muu
+{
+	inline namespace integer_aliases
+	{
+		using i8  = int8_t;
+		using i16 = int16_t
+		using i32 = int32_t;
+		using i64 = int64_t;
+		using u8  = uint8_t;
+		using u16 = uint16_t;
+		using u32 = uint32_t;
+		using u64 = uint64_t;
+	}
+}

--- a/muu.vcxproj
+++ b/muu.vcxproj
@@ -92,6 +92,7 @@
     <ClInclude Include="include\muu\half.h" />
     <ClInclude Include="include\muu\hashing.h" />
     <ClInclude Include="include\muu\integer_literals.h" />
+    <ClInclude Include="include\muu\integer_aliases.h" />
     <ClInclude Include="include\muu\source_location.h" />
     <ClInclude Include="include\muu\static_array.h" />
     <ClInclude Include="include\muu\launder.h" />

--- a/muu.vcxproj.filters
+++ b/muu.vcxproj.filters
@@ -304,6 +304,9 @@
     <ClInclude Include="include\muu\integer_literals.h">
       <Filter>include</Filter>
     </ClInclude>
+    <ClInclude Include="include\muu\integer_aliases.h">
+      <Filter>include</Filter>
+    </ClInclude>
     <ClInclude Include="include\muu\launder.h">
       <Filter>include</Filter>
     </ClInclude>

--- a/muu_static.vcxproj
+++ b/muu_static.vcxproj
@@ -92,6 +92,7 @@
     <ClInclude Include="include\muu\half.h" />
     <ClInclude Include="include\muu\hashing.h" />
     <ClInclude Include="include\muu\integer_literals.h" />
+    <ClInclude Include="include\muu\integer_aliases.h" />
     <ClInclude Include="include\muu\source_location.h" />
     <ClInclude Include="include\muu\static_array.h" />
     <ClInclude Include="include\muu\launder.h" />

--- a/muu_static.vcxproj.filters
+++ b/muu_static.vcxproj.filters
@@ -304,6 +304,9 @@
     <ClInclude Include="include\muu\integer_literals.h">
       <Filter>include</Filter>
     </ClInclude>
+    <ClInclude Include="include\muu\integer_aliases.h">
+      <Filter>include</Filter>
+    </ClInclude>
     <ClInclude Include="include\muu\launder.h">
       <Filter>include</Filter>
     </ClInclude>

--- a/tests/vs/muu_debug_x64.vcxproj
+++ b/tests/vs/muu_debug_x64.vcxproj
@@ -97,6 +97,7 @@
     <ClInclude Include="$(SolutionDir)include\muu\half.h" />
     <ClInclude Include="$(SolutionDir)include\muu\hashing.h" />
     <ClInclude Include="$(SolutionDir)include\muu\integer_literals.h" />
+    <ClInclude Include="$(SolutionDir)include\muu\integer_aliases.h" />
     <ClInclude Include="$(SolutionDir)include\muu\source_location.h" />
     <ClInclude Include="$(SolutionDir)include\muu\static_array.h" />
     <ClInclude Include="$(SolutionDir)include\muu\launder.h" />

--- a/tests/vs/muu_debug_x64_cpplatest.vcxproj
+++ b/tests/vs/muu_debug_x64_cpplatest.vcxproj
@@ -97,6 +97,7 @@
     <ClInclude Include="$(SolutionDir)include\muu\half.h" />
     <ClInclude Include="$(SolutionDir)include\muu\hashing.h" />
     <ClInclude Include="$(SolutionDir)include\muu\integer_literals.h" />
+    <ClInclude Include="$(SolutionDir)include\muu\integer_aliases.h" />
     <ClInclude Include="$(SolutionDir)include\muu\source_location.h" />
     <ClInclude Include="$(SolutionDir)include\muu\static_array.h" />
     <ClInclude Include="$(SolutionDir)include\muu\launder.h" />

--- a/tests/vs/muu_debug_x64_noexcept.vcxproj
+++ b/tests/vs/muu_debug_x64_noexcept.vcxproj
@@ -97,6 +97,7 @@
     <ClInclude Include="$(SolutionDir)include\muu\half.h" />
     <ClInclude Include="$(SolutionDir)include\muu\hashing.h" />
     <ClInclude Include="$(SolutionDir)include\muu\integer_literals.h" />
+    <ClInclude Include="$(SolutionDir)include\muu\integer_aliases.h" />
     <ClInclude Include="$(SolutionDir)include\muu\source_location.h" />
     <ClInclude Include="$(SolutionDir)include\muu\static_array.h" />
     <ClInclude Include="$(SolutionDir)include\muu\launder.h" />

--- a/tests/vs/muu_release_x64.vcxproj
+++ b/tests/vs/muu_release_x64.vcxproj
@@ -97,6 +97,7 @@
     <ClInclude Include="$(SolutionDir)include\muu\half.h" />
     <ClInclude Include="$(SolutionDir)include\muu\hashing.h" />
     <ClInclude Include="$(SolutionDir)include\muu\integer_literals.h" />
+    <ClInclude Include="$(SolutionDir)include\muu\integer_aliases.h" />
     <ClInclude Include="$(SolutionDir)include\muu\source_location.h" />
     <ClInclude Include="$(SolutionDir)include\muu\static_array.h" />
     <ClInclude Include="$(SolutionDir)include\muu\launder.h" />

--- a/tests/vs/muu_release_x64_cpplatest.vcxproj
+++ b/tests/vs/muu_release_x64_cpplatest.vcxproj
@@ -97,6 +97,7 @@
     <ClInclude Include="$(SolutionDir)include\muu\half.h" />
     <ClInclude Include="$(SolutionDir)include\muu\hashing.h" />
     <ClInclude Include="$(SolutionDir)include\muu\integer_literals.h" />
+    <ClInclude Include="$(SolutionDir)include\muu\integer_aliases.h" />
     <ClInclude Include="$(SolutionDir)include\muu\source_location.h" />
     <ClInclude Include="$(SolutionDir)include\muu\static_array.h" />
     <ClInclude Include="$(SolutionDir)include\muu\launder.h" />

--- a/tests/vs/muu_release_x64_noexcept.vcxproj
+++ b/tests/vs/muu_release_x64_noexcept.vcxproj
@@ -97,6 +97,7 @@
     <ClInclude Include="$(SolutionDir)include\muu\half.h" />
     <ClInclude Include="$(SolutionDir)include\muu\hashing.h" />
     <ClInclude Include="$(SolutionDir)include\muu\integer_literals.h" />
+    <ClInclude Include="$(SolutionDir)include\muu\integer_aliases.h" />
     <ClInclude Include="$(SolutionDir)include\muu\source_location.h" />
     <ClInclude Include="$(SolutionDir)include\muu\static_array.h" />
     <ClInclude Include="$(SolutionDir)include\muu\launder.h" />

--- a/tools/generate_float_tests_header.py
+++ b/tools/generate_float_tests_header.py
@@ -251,7 +251,7 @@ class FloatTraits(object):
 		dec = dec.normalize()
 		if dec.is_zero():
 			return '0' * self.total_bits
-		
+
 		#return ''.join('{:0>8b}'.format(c) for c in struct.pack('>e', float(dec)))
 
 		sign_bit = '1' if dec < D(0) else '0'
@@ -261,7 +261,7 @@ class FloatTraits(object):
 		dprint('----------------')
 		dprint(f'value:           {dec}')
 		dprint('sign_bit:        ' + sign_bit)
-		
+
 		integral = int(dec.to_integral_value(rounding=decimal.ROUND_FLOOR))
 		fractional = dec
 		if integral > 0:
@@ -274,11 +274,11 @@ class FloatTraits(object):
 		assert (integral + fractional) == dec, f"{integral}.{fractional} == {dec}"
 		dprint(f'integral:        {integral}')
 		dprint(f'fractional:      {fractional}')
-		
+
 		integral_bits = ''
 		if integral > 0:
 			integral_bits = bin(integral)[2:]
-		
+
 		float_exponent_offset = 0
 		fractional_bits = ''
 		prev_prec = decimal.getcontext().prec
@@ -306,19 +306,19 @@ class FloatTraits(object):
 
 		dprint('integral_bits:   ' + integral_bits)
 		dprint('fractional_bits: ' + fractional_bits)
-		
+
 		if (len(integral_bits) + len(fractional_bits)) > (self.significand_bits + 1):
 			if len(integral_bits) > (self.significand_bits + 1):
 				raise Exception("eh")
 			fractional_bits = round_binary(fractional_bits, self.significand_bits + 1 - len(integral_bits))
-		
+
 		mantissa_bits = (integral_bits + fractional_bits)#[:self.significand_bits]
 		if self.integer_part_bits == 0 and mantissa_bits[0] == '1':
 			mantissa_bits = mantissa_bits[1:]
 		if len(mantissa_bits) < self.significand_bits:
 			mantissa_bits = mantissa_bits + '0' * (self.significand_bits - len(mantissa_bits))
 		dprint('mantissa_bits:   ' + mantissa_bits)
-		
+
 		exponent = None
 		if integral > 0:
 			exponent = len(integral_bits) - 1
@@ -330,7 +330,7 @@ class FloatTraits(object):
 		if exponent is None:
 			exponent = 0
 		dprint(f'exponent:        {exponent}')
-		
+
 		exponent_bits = ''
 		exponent = exponent + self.exponent_bias
 		bit = 1 << (self.exponent_bits-1)
@@ -341,7 +341,7 @@ class FloatTraits(object):
 				exponent_bits = exponent_bits + '0'
 			bit = bit >> 1
 		dprint('exponent_bits:   ' + exponent_bits)
-		
+
 		return (self.padding_bits * '0') + sign_bit + "'" + exponent_bits + "'" + mantissa_bits
 
 
@@ -508,7 +508,7 @@ def write_float_data(file, traits):
 
 
 def main():
-	
+
 	file_path = Path(utils.entry_script_dir(), '..', 'tests', 'float_test_data.h').resolve()
 	with StringIO() as buf:
 		indent = 0
@@ -544,7 +544,7 @@ def main():
 		write('')
 		write('namespace muu')
 		write('{')
-		indent = indent + 1 
+		indent = indent + 1
 
 		# data tables
 		write('template <size_t TotalBits, size_t SignificandBits>')
@@ -573,7 +573,7 @@ def main():
 		write('template <typename T>')
 		write('struct float_test_data : float_test_data_by_traits<sizeof(T) * CHAR_BIT, constants<T>::significand_digits> {};')
 
-		indent = indent - 1 
+		indent = indent - 1
 		write('}')
 
 		write('')
@@ -582,7 +582,7 @@ def main():
 		print("Writing to {}".format(file_path))
 		with open(file_path, 'w', encoding='utf-8', newline='\n') as file:
 			file.write(utils.clang_format(buf.getvalue()))
-		
+
 
 if __name__ == '__main__':
 	utils.run(main)


### PR DESCRIPTION
Added shorthands for fixed-width integer types, as they tend to get noisy without type deduction.


- [x] I've read [CONTRIBUTING.md]
- [ ] I've added new test cases to verify my change
- [ ] I've updated any affected documentation
- [x] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 9 or higher
    - [ ] GCC 9 or higher
    - [x] Visual Studio 2022
